### PR TITLE
Remove unnecessary build jobs from exercise 6 and 7 docs

### DIFF
--- a/docs/exercise-006.md
+++ b/docs/exercise-006.md
@@ -28,11 +28,6 @@ image_resource:
   type: docker-image
   source: {repository: openjdk, tag: 8}
 
-run:
-  path: ./gradlew # Command to execute
-  args: ["build"]
-  dir: sources/application # Location to execute, note the 'sources' as directory prefix
-
 run: # Gradle release + version bumping
   path: sh
   args:

--- a/docs/exercise-007.md
+++ b/docs/exercise-007.md
@@ -36,11 +36,6 @@ image_resource:
   type: docker-image
   source: {repository: openjdk, tag: 8}
 
-run:
-  path: ./gradlew # Command to execute
-  args: ["build"]
-  dir: sources/application # Location to execute, note the 'sources' as directory prefix
-
 run: # Gradle release + version bumping
   path: sh
   args:


### PR DESCRIPTION
The documents for exercise 6 and 7 instruct you to add a job for building the project. This is not necessary, as we just download the artifact from Nexus and run it.